### PR TITLE
Use `git worktree` for generating the linter baseline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,25 @@
+Unreleased_
+===========
+
+These features will be included in the next release:
+
+Added
+-----
+- Copied linting related code from Darker 1.7.0.
+
+Fixed
+-----
+- Use ``git worktree`` instead of ``git clone`` and ``git checkout`` to set up a
+  temporary working tree for running linters for a baseline in the ``rev1`` revision of
+  the repository.
+
+
+Darker 0.1.0 to 0.7.0
+======================
+
+For changes before the migration of code from Darker to Darkgraylib and Graylint, see
+`CHANGES.rst in the Darker repository`__.
+
+__ https://github.com/akaihola/darker/blob/master/CHANGES.rst
+
+.. _Unreleased: https://github.com/akaihola/graylint/compare/860c231...HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: MIT License"]
 dynamic = ["version", "description"]
 dependencies = [
-    "darkgraylib @ git+https://github.com/akaihola/darkgraylib.git@469ad599",
+    "darkgraylib @ git+https://github.com/akaihola/darkgraylib.git@main",
 ]
 
 [project.scripts]

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -523,17 +523,18 @@ def _get_messages_from_linters_for_baseline(
     :return: Linter messages
 
     """
-    with TemporaryDirectory() as tmp_path:
-        clone_root = git_clone_local(root, revision, Path(tmp_path))
-        rev1_commit = git_rev_parse(revision, root)
-        result = _get_messages_from_linters(
-            linter_cmdlines,
-            clone_root,
-            paths,
-            make_linter_env(root, rev1_commit),
-            normalize_whitespace,
-        )
-        fix_py37_win_tempdir_permissions(tmp_path)
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir) / "baseline-revision"
+        with git_clone_local(root, revision, tmp_path) as clone_root:
+            rev1_commit = git_rev_parse(revision, root)
+            result = _get_messages_from_linters(
+                linter_cmdlines,
+                clone_root,
+                paths,
+                make_linter_env(root, rev1_commit),
+                normalize_whitespace,
+            )
+            fix_py37_win_tempdir_permissions(tmpdir)
     return result
 
 


### PR DESCRIPTION
`actions/checkout@v3` clones a repository in a way which doesn't allow checking out arbitrary branches after making a local clone using `git clone <path1> <path2>`. This effectively broke linting in the Darker action in version 1.7.0.

The fix is to use `git worktree` instead of `git clone` and `git checkout` to create a local copy of the repository.

This was fixed in akaihola/darker#470. Since some of the touched code is moving to `graylint`, the fix is replicated here.