### PR TITLE
Omit missing paths from linter command lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Fixed
 - Use ``git worktree`` instead of ``git clone`` and ``git checkout`` to set up a
   temporary working tree for running linters for a baseline in the ``rev1`` revision of
   the repository.
+- Omit missing paths from linter command lines. Mypy was known to lint nothing if any
+  of the paths on the command line didn't exist.
 
 
 Darker 0.1.0 to 0.7.0

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -298,7 +298,8 @@ def _check_linter_output(
         cmdline_parts = shlex.split(cmdline, posix=not WINDOWS)
     else:
         cmdline_parts = cmdline
-    cmdline_and_paths = cmdline_parts + [str(path) for path in sorted(paths)]
+    existing_path_strs = sorted(str(path) for path in paths if (root / path).exists())
+    cmdline_and_paths = cmdline_parts + existing_path_strs
     logger.debug("[%s]$ %s", root, shlex.join(cmdline_and_paths))
     with Popen(  # nosec
         cmdline_and_paths,

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -467,6 +467,29 @@ def _get_messages_from_linters(
     return result
 
 
+def _log_messages(
+    baseline: Dict[MessageLocation, List[LinterMessage]],
+    new_messages: Dict[MessageLocation, List[LinterMessage]],
+) -> None:
+    """Output recorded messages at baseline and at rev2 to debug log, no highlighting
+
+    :param baseline: The baseline messages recorded for revision ``rev1``
+    :param new_messages: The new messages recorded for revision ``rev2``
+
+    """
+    for title, message_set in [
+        ("BASELINE AT REV1", baseline),
+        ("CURRENT AT REV2", new_messages),
+    ]:
+        logger.debug("%s:", title)
+        logger.debug(len(title) * "=")
+        for message_location, messages in sorted(message_set.items()):
+            for message in messages:
+                logger.debug(
+                    "%s: %s [%s]", message_location, message.description, message.linter
+                )
+
+
 def _print_new_linter_messages(
     baseline: Dict[MessageLocation, List[LinterMessage]],
     new_messages: Dict[MessageLocation, List[LinterMessage]],
@@ -482,6 +505,8 @@ def _print_new_linter_messages(
     :return: The number of linter errors displayed
 
     """
+    if logger.getEffectiveLevel() <= logging.DEBUG:
+        _log_messages(baseline, new_messages)
     error_count = 0
     prev_location = NO_MESSAGE_LOCATION
     for message_location, messages in sorted(new_messages.items()):

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -190,7 +190,7 @@ def test_check_linter_output(tmp_path, cmdline, expect):
     with linting._check_linter_output(
         cmdline,
         tmp_path,
-        {Path("first.py"), Path("the  2nd.py")},
+        {Path("first.py"), Path("the  2nd.py"), Path("missing.py")},
         make_linter_env(tmp_path, "WORKTREE"),
     ) as stdout:
         lines = list(stdout)


### PR DESCRIPTION
Fixes #9.

Mypy was known to lint nothing if any of the paths on the command line didn't exist. 