### PR TITLE
Skip tests on Python 3.13-dev in Windows and macOS

### DIFF
--- a/.github/workflows/package-and-test.yml
+++ b/.github/workflows/package-and-test.yml
@@ -96,6 +96,13 @@ jobs:
           - '3.13-dev'
         constraints: ['']
         post_install: ['']
+        exclude:
+          # C extension builds failing.
+          # Remove exclusions after Python 3.13 release.
+          - os: windows-latest
+            python-version: '3.13-dev'
+          - os: macos-latest
+            python-version: '3.13-dev'
         include:
           - os: ubuntu-latest
             python-version: '3.8'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Removed
 -------
 - Dependency on flynt and regex.
 - Obsolete Mypy configuration options.
+- Skip tests on Python 3.13-dev in Windows and macOS. C extension builds are failing,
+  this exclusion is to be removed when Python 3.13 has been removed.
 
 Fixed
 -----


### PR DESCRIPTION
Some C extension builds fail with Python 3.13-dev on Windows and macOS.

We should remove exclusions after Python 3.13 release.

Copied from akaihola/darkgraylib#49.