### PR TITLE
Pass "graylint" to config dump function to get the correct configuration section name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Added
 
 Fixed
 -----
+- In the configuration dump printed when ``-vv`` verbosity is used, the configuration
+  section is now correctly named ``[tool.graylint]`` instead of ``[tool.darkgraylib]``.
+  This required an update to Darkgraylib 1.3.0.
 
 
 1.1.1_ - 2024-04-13

--- a/constraints-oldest.txt
+++ b/constraints-oldest.txt
@@ -4,7 +4,7 @@
 # interpreter and Python ependencies. Keep this up-to-date with minimum
 # versions in `setup.cfg`.
 airium==0.2.3
-darkgraylib==1.2.0
+darkgraylib==1.3.0
 defusedxml==0.7.1
 flake8-2020==1.6.1
 flake8-bugbear==22.1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
 packages = find:
 install_requires =
     # NOTE: remember to keep `constraints-oldest.txt` in sync with these
-    darkgraylib~=1.2.0
+    darkgraylib~=1.3.0
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync
 #       with the minimum required Python version
 python_requires = >=3.8

--- a/src/graylint/__main__.py
+++ b/src/graylint/__main__.py
@@ -39,7 +39,7 @@ def main(argv: list[str] = None) -> int:
         make_argument_parser, argv, "graylint", GraylintConfig
     )
     setup_logging(args.log_level)
-    show_config_if_debug(config, config_nondefault, args.log_level)
+    show_config_if_debug(config, config_nondefault, args.log_level, "graylint")
     paths, root = resolve_paths(args.stdin_filename, args.src)
     revrange = RevisionRange.parse_with_common_ancestor(
         args.revision, root, args.stdin_filename is not None


### PR DESCRIPTION
Next:
- [x] #akaihola/darkgraylib#61
- [x] #akaihola/darkgraylib#63

----

`graylint -vv .` used to output:

```toml
# Effective configuration:

[tool.darkgraylib]
# [...]


# Configuration options which differ from defaults:

[tool.darkgraylib]
# [...]
```

This patch corrects it to:

```toml
# Effective configuration:

[tool.graylint]
# [...]


# Configuration options which differ from defaults:

[tool.graylint]
# [...]
```

Darkgraylib 1.3.0 now requires the section name argument, which we are passing in since this PR.