### PR TITLE
Fix version specified for pre-commit in readme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Added
 
 Fixed
 -----
+- Version tag in pre-commit instructions.
 
 
 2.0.0_ - 2024-07-31

--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,7 @@ do the following:
    .. code-block:: yaml
 
       - repo: https://github.com/akaihola/graylint
-        rev: 1.0.0
+        rev: v2.0.0
         hooks:
           - id: graylint
 
@@ -308,7 +308,7 @@ you use to known compatible versions, for example:
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/graylint
-     rev: 1.0.0
+     rev: v2.0.0
      hooks:
        - id: graylint
          args:
@@ -337,7 +337,7 @@ Note the inclusion of the ``ruff`` Python package under ``additional_dependencie
 .. code-block:: yaml
 
    - repo: https://github.com/akaihola/graylint
-     rev: 1.0.0
+     rev: v2.0.0
      hooks:
        - id: graylint
          args: [--lint "ruff check"]


### PR DESCRIPTION
Was testing out this today and ran into this issue when following the readme to setup a pre-commit hook
```
[INFO] Initializing environment for https://github.com/akaihola/graylint.
An unexpected error has occurred: CalledProcessError: command: ('/usr/lib/git-core/git', 'checkout', '1.0.0')
return code: 1
stdout: (none)
stderr:
    error: pathspec '1.0.0' did not match any file(s) known to git
```
Issue was a missing `v` at the start. Also bumped the version to 2.0.0
