### PR TITLE
Speed up parameterized tests which use Git

### DIFF
--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -591,22 +591,20 @@ class AssertEmptyStderrPopen(Popen[str]):  # pylint: disable=too-few-public-meth
         assert self.stderr.read() == ""
 
 
-def test_get_messages_from_linters_for_baseline_no_mypy_errors(git_repo):
+def test_get_messages_from_linters_for_baseline_no_mypy_errors(simple_test_repo):
     """Ensure Mypy does not fail early when ``__init__.py`` is at the repository root
 
     Regression test for #498
 
     """
-    git_repo.add({"__init__.py": ""}, commit="Initial commit")
-    initial = git_repo.get_hash()
     with patch.object(linting, "Popen", AssertEmptyStderrPopen):
         # end of test setup
 
         _ = linting._get_messages_from_linters_for_baseline(
             linter_cmdlines=[["mypy"]],
-            root=git_repo.root,
+            root=simple_test_repo.root,
             paths=[Path("__init__.py")],
-            revision=initial,
+            revision=simple_test_repo.hash_initial,
         )
 
 

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -365,19 +365,17 @@ def simple_test_repo(request, tmp_path_factory):
     "message, expect",
     [
         ("", 0),
-        ("test.py:1: message on modified line", 1),
-        ("test.py:2: message on unmodified line", 0),
+        ("__init__.py:1: message on modified line", 1),
+        ("__init__.py:4: message on unmodified line", 0),
     ],
 )
-def test_run_linters_return_value(git_repo, message, expect):
+def test_run_linters_return_value(simple_test_repo, message, expect):
     """``run_linters()`` returns the number of linter errors on modified lines"""
-    src_paths = git_repo.add({"test.py": "1\n2\n"}, commit="Initial commit")
-    src_paths["test.py"].write_bytes(b"one\n2\n")
     cmdline = ["echo", message]
 
     result = linting.run_linters(
         [cmdline],
-        git_repo.root,
+        simple_test_repo.root,
         {Path("test.py")},
         RevisionRange("HEAD", ":WORKTREE:"),
         [OutputSpec("gnu")],

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -1,12 +1,13 @@
 """Unit tests for `graylint.linting`."""
 
-# pylint: disable=protected-access,redefined-outer-name,too-many-arguments
+# pylint: disable=no-member,protected-access,redefined-outer-name,too-many-arguments
 # pylint: disable=use-dict-literal
 
 import os
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from textwrap import dedent
+from types import SimpleNamespace
 from typing import Any, Dict, Iterable, List, Tuple, Union
 from unittest.mock import patch
 
@@ -342,6 +343,21 @@ def test_run_linters_non_worktree():
                 "..HEAD", Path("dummy cwd"), stdin_mode=False
             ),
             [OutputSpec("gnu")],
+        )
+
+
+@pytest.fixture(scope="module")
+def simple_test_repo(request, tmp_path_factory):
+    """Git repository fixture for `test_run_linters`."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        paths = repo.add({"__init__.py": "1\n2\n3\n4\n5\n6\n"}, commit="Initial commit")
+        initial = repo.get_hash()
+        repo.create_tag("initial")
+        paths["__init__.py"].write_bytes(b"a\nb\nc\n4\ne\nf\n")
+        yield SimpleNamespace(
+            root=repo.root,
+            paths=paths,
+            hash_initial=initial,
         )
 
 

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -3,12 +3,14 @@
 # pylint: disable=no-member,protected-access,redefined-outer-name,too-many-arguments
 # pylint: disable=use-dict-literal
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import Any, Dict, Iterable, List, Tuple, Union
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -25,6 +27,9 @@ from graylint.linting import (
     MessageLocation,
     make_linter_env,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 SKIP_ON_WINDOWS = [pytest.mark.skip] if WINDOWS else []
 SKIP_ON_UNIX = [] if WINDOWS else [pytest.mark.skip]
@@ -464,8 +469,8 @@ def test_run_linters_stdin():
 
 
 def _build_messages(
-    lines_and_messages: Iterable[Union[Tuple[int, str], Tuple[int, str, str]]],
-) -> Dict[MessageLocation, List[LinterMessage]]:
+    lines_and_messages: Iterable[tuple[int, str] | tuple[int, str, str]],
+) -> dict[MessageLocation, list[LinterMessage]]:
     return {
         MessageLocation(Path("a.py"), line, 0): [
             LinterMessage(*msg.split(":")) for msg in msgs
@@ -585,7 +590,12 @@ def test_get_messages_from_linters_for_baseline(git_repo):
 class AssertEmptyStderrPopen(Popen[str]):  # pylint: disable=too-few-public-methods
     """A Popen to use for the following test; asserts that its stderr is empty"""
 
-    def __init__(self, args: List[str], **kwargs: Any):  # type: ignore[explicit-any]
+    def __init__(  # type: ignore[explicit-any]
+        self,
+        args: list[str],
+        **kwargs: Any,  # noqa: ANN401
+    ):
+        """Initialize the Popen object and assert that its stderr is empty."""
         super().__init__(args, stderr=PIPE, **kwargs)
         assert self.stderr is not None
         assert self.stderr.read() == ""


### PR DESCRIPTION
This is done by using the new module-scoped Git repository fixture from Darkgraylib.

- [x] Merge akaihola/darkgraylib#84
- [x] Release Darkgraylib
- [x] Bump required minimum version of Darkgraylib 
- [x] Merge #71

To get aggregate timings for parameterized tests:
```bash
pip install pytest-reportlog
pytest --report-log=pytest.log.json
python analyze_pytest_log.py
```
<details>
<summary>analyze_pytest_log.py</summary>

```python
import json
from collections import defaultdict


def aggregate_test_durations(log_contents):
    """Aggregate durations of parameterized tests from pytest-reportlog output.

    Args:
        log_contents (str): The contents of the pytest-reportlog file

    Returns:
        dict: A dictionary mapping test names to their total duration

    """
    # Dictionary to store total durations for each base test name
    test_durations = defaultdict(float)

    # Process each line
    for line in log_contents.strip().split("\n"):
        try:
            report = json.loads(line)

            # Extract the base test name by removing the parameter portion
            full_nodeid = report["nodeid"]
            base_name = full_nodeid.split("[")[0]

            # Add the duration to the total for this test
            test_durations[base_name] += report["duration"]

        except (json.JSONDecodeError, KeyError, IndexError) as e:
            print(f"Error processing line: {e} in {line}")
            continue

    return dict(test_durations)

def main():
    # Sample usage
    log_contents = open("pytest.log.json").read()

    results = aggregate_test_durations(log_contents)

    # Print results in a formatted way
    print("\nAggregated test durations:")
    print("-" * 50)
    by_duration = sorted(results.items(), key=lambda x: x[1], reverse=True)
    for test_name, duration in by_duration:
        print(f"{test_name:<40} {duration:.6f} seconds")

if __name__ == "__main__":
    main()
```
</details>