### PR TITLE
Enforce UTF-8 encoding for linter subprocess on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Removed
 Fixed
 -----
 - Version tag in pre-commit instructions.
+- Enforce UTF-8 encoding when calling linter subprocesses on Windows.
 
 Internal
 --------
@@ -36,6 +37,8 @@ Internal
 - Update Nix action to v31 – fixes the build error.
 - Update to ``pylint-per-file-ignores>=2.0.0`` and fix its configuration syntax.
 - Install Pytest_ in Graylint-based CI workflows.
+- Avoid a buggy ``flake8-bugbear`` version in the CI build.
+- Automation for updating version strings in README using ``darkgray_bump_version``.
 
 
 2.0.0_ - 2024-07-31

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -51,6 +51,7 @@ from darkgraylib.git import (
     git_get_root,
     git_rev_parse,
 )
+from darkgraylib.utils import WINDOWS
 from graylint.output.plugin_helpers import create_output_plugins
 
 if TYPE_CHECKING:
@@ -296,12 +297,15 @@ def _check_linter_output(
     existing_path_strs = sorted(str(path) for path in paths if (root / path).exists())
     cmdline_and_paths = cmdline + existing_path_strs
     logger.debug("[%s]$ %s", root, shlex.join(cmdline_and_paths))
+    effective_env = env.copy()
+    if WINDOWS:
+        effective_env["PYTHONIOENCODING"] = "utf-8"
     with Popen(  # nosec
         cmdline_and_paths,
         stdout=PIPE,
         encoding="utf-8",
         cwd=root,
-        env=env,
+        env=effective_env,
     ) as linter_process:
         # condition needed for MyPy (see https://stackoverflow.com/q/57350490/15770)
         if linter_process.stdout is None:


### PR DESCRIPTION
On Windows, linting UTF-8 files with non-ASCII characters fails. This patch enforces UTF-8 encoding when calling linter subprocesses.

```python
$ graylint -L pylint src
Exception on node <Call l.341 at 0x1fb7ece0610> in file 'tmp437lpsx3\baseline-revision\darkgraylib\src\darkgraylib\tests\test_git.py'
Traceback (most recent call last):
  File "pylint\utils\ast_walker.py", line 91, in walk
    callback(astroid)
  File "pylint\checkers\refactoring\refactoring_checker.py", line 1161, in visit_call
    self._check_use_dict_literal(node)
  File "pylint\checkers\refactoring\refactoring_checker.py", line 1727, in _check_use_dict_literal
    self.add_message(
  File "pylint\checkers\base_checker.py", line 153, in add_message
    self.linter.add_message(
  File "pylint\lint\pylinter.py", line 1270, in add_message
    self._add_one_message(
  File "pylint\lint\pylinter.py", line 1228, in _add_one_message
    self.reporter.handle_message(
  File "pylint\reporters\text.py", line 161, in handle_message
    self.write_message(msg)
  File "pylint\reporters\text.py", line 154, in write_message
    self.writeln(self._fixed_template.format(**self_dict))
  File "pylint\reporters\base_reporter.py", line 45, in writeln
    print(string, file=self.out)
  File "Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 145-148: character maps to <undefined>
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='cp1252'>
OSError: [Errno 22] Invalid argument
ERROR:graylint.__main__:'utf-8' codec can't decode byte 0xe9 in position 2838: invalid continuation byte (123)
Traceback (most recent call last):
  File "graylint\src\graylint\__main__.py", line 29, in main_with_error_handling
    return main(argv)
           ^^^^^^^^^^
  File "graylint\src\graylint\__main__.py", line 53, in main
    linter_failures_on_modified_lines = run_linters(
                                        ^^^^^^^^^^^^
  File "graylint\src\graylint\linting.py", line 423, in run_linters
    # 10. first do a temporary checkout at `rev1` and run linter subprocesses once for
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "graylint\src\graylint\linting.py", line 562, in _get_messages_from_linters_for_baseline
    tmp_path = Path(tmpdir) / "baseline-revision" / root.name
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "graylint\src\graylint\linting.py", line 473, in _get_messages_from_linters
    """

  File "graylint\src\graylint\linting.py", line 351, in run_linter
    #     modified or unmodified, to get current linting status in the working tree
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 2838: invalid continuation byte
```