### PR TITLE
Output plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,12 @@ disable = ["wrong-import-order"]
 
 [tool.ruff]
 target-version = "py38"
+output-format = "concise"
 
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-    "ANN101",  # Missing type annotation for `self` in method
+    "COM812",  # Trailing comma missing
     "D203",  # One blank line required before class docstring
     "D213",  # Multi-line docstring summary should start at the second line
     "D400",  # First line should end with a period (duplicates D415)
@@ -51,6 +52,7 @@ ignore = [
     "C408",  # Unnecessary `dict` call (rewrite as a literal)
     "PLR0913",  # Too many arguments in function definition
     "S101",  # Use of `assert` detected
+    "SLF001",  # Private member accessed
 ]
 
 [tool.ruff.lint.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,9 @@ graylint =
   tests/*.py
 
 [options.entry_points]
+graylint.output_format =
+    gnu = graylint.output.gnu:GnuErrorFormatOutputPlugin
+    github = graylint.output.github:GitHubOutputPlugin
 console_scripts =
     graylint = graylint.__main__:main_with_error_handling
 

--- a/src/graylint/__main__.py
+++ b/src/graylint/__main__.py
@@ -50,13 +50,17 @@ def main(argv: list[str] = None) -> int:
     revrange = RevisionRange.parse_with_common_ancestor(
         args.revision, root, args.stdin_filename is not None
     )
+    output_formats = [
+        output.with_color(use_color=should_use_color(config["color"]))
+        for output in args.output_format
+    ]
     linter_failures_on_modified_lines = run_linters(
         args.lint,
         root,
         # paths to lint are not limited to modified files or just Python files:
         {p.resolve().relative_to(root) for p in paths},
         revrange,
-        use_color=should_use_color(config["color"]),
+        output_formats,
     )
     return 1 if linter_failures_on_modified_lines else 0
 

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -14,8 +14,6 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
 
     :param require_src: ``True`` to require at least one path as a positional argument
                         on the command line. ``False`` to not require on.
-    :param description: The descriptive text for the application to be shown in
-                        ``--help`` output.
 
     """
     parser = darkgraylib.command_line.make_argument_parser(

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -33,14 +33,3 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
 
     add_arg(hlp.LINT, "-L", "--lint", action="append", metavar="CMD", default=[])
     return parser
-
-
-def add_lint_arg(parser: ArgumentParser) -> None:
-    """Add the ``-L`` / ``--lint`` argument to the parser
-
-    :parser: The parser to add the argument to
-
-    """
-    add_parser_argument(
-        parser, hlp.LINT, "-L", "--lint", action="append", metavar="CMD", default=[]
-    )

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -1,10 +1,30 @@
 """Command line parsing for the ``graylint`` binary"""
 
-from argparse import ArgumentParser
+from argparse import Action, ArgumentParser, Namespace
+from typing import Any, Sequence
 
 import darkgraylib.command_line
 from graylint import help as hlp
 from graylint.version import __version__
+
+
+class ExtendFromEmptyAction(Action):
+    """Action to replace a default list with values from the command line."""
+
+    def __call__(
+        self,
+        parser: ArgumentParser,  # noqa: ARG002
+        namespace: Namespace,
+        values: str | Sequence[Any] | None,
+        option_string: str | None = None,
+    ) -> None:
+        """Return items from command line or the default list if omitted."""
+        if not isinstance(values, Sequence):
+            message = "Expected a sequence of values"
+            raise TypeError(message)
+        items = [] if option_string else self.default
+        items.extend(values)
+        setattr(namespace, self.dest, items)
 
 
 def make_argument_parser(require_src: bool) -> ArgumentParser:

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -1,5 +1,7 @@
 """Command line parsing for the ``graylint`` binary"""
 
+from __future__ import annotations
+
 from argparse import Action, ArgumentParser, Namespace
 from typing import Any, Sequence
 
@@ -25,6 +27,11 @@ class ExtendFromEmptyAction(Action):
         items = [] if option_string else self.default
         items.extend(values)
         setattr(namespace, self.dest, items)
+
+
+def parse_format_args(value: str) -> list[OutputSpec]:
+    """Parse comma-separated format specifications."""
+    return [OutputSpec.parse(v.strip()) for v in value.split(",")]
 
 
 def make_argument_parser(require_src: bool) -> ArgumentParser:

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from argparse import Action, ArgumentParser, Namespace
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Sequence
 
 import darkgraylib.command_line
 from graylint import help as hlp
+from graylint.output import OUTPUT_FORMAT_GROUP
+from graylint.output.destination import OutputDestination
 from graylint.version import __version__
 
 
@@ -27,6 +31,33 @@ class ExtendFromEmptyAction(Action):
         items = [] if option_string else self.default
         items.extend(values)
         setattr(namespace, self.dest, items)
+
+
+@dataclass
+class OutputSpec:
+    """Specification for an output format."""
+
+    format: str
+    path: OutputDestination = field(default_factory=lambda: OutputDestination("-"))
+    use_color: bool = False
+
+    @classmethod
+    def parse(cls, value: str) -> OutputSpec:
+        """Parse a format specification string into a FormatSpec object."""
+        if ":" in value:
+            fmt, path = Path(value.split(":", 1))
+        else:
+            fmt, path = value, "-"
+
+        if fmt not in get_entry_point_names(OUTPUT_FORMAT_GROUP):
+            message = f"Unknown output format: {fmt}"
+            raise ValueError(message)
+
+        return cls(fmt, OutputDestination(path))
+
+    def with_color(self, *, use_color: bool) -> OutputSpec:
+        """Return a copy with color output enabled or disabled."""
+        return OutputSpec(self.format, self.path, use_color)
 
 
 def parse_format_args(value: str) -> list[OutputSpec]:

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import darkgraylib.command_line
+from darkgraylib.plugins import get_entry_point_names
 from graylint import help as hlp
 from graylint.output import OUTPUT_FORMAT_GROUP
 from graylint.output.destination import OutputDestination
@@ -82,4 +83,19 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
     )
 
     parser.add_argument("-L", "--lint", action="append", metavar="CMD", default=[])
+    output_formats = get_entry_point_names(OUTPUT_FORMAT_GROUP)
+    default_output_format = output_formats[0]
+    output_format_names = ", ".join(
+        f"{name} (default)" if name == default_output_format else name
+        for name in output_formats
+    )
+    parser.add_argument(
+        "-o",
+        "--output-format",
+        action=ExtendFromEmptyAction,
+        type=parse_format_args,
+        metavar="FORMAT[:PATH]",
+        default=[OutputSpec("gnu", OutputDestination("-"))],
+        help=hlp.FORMAT_TEMPLATE.format(output_format_names=output_format_names),
+    )
     return parser

--- a/src/graylint/command_line.py
+++ b/src/graylint/command_line.py
@@ -1,10 +1,8 @@
 """Command line parsing for the ``graylint`` binary"""
 
 from argparse import ArgumentParser
-from typing import Any, Optional
 
 import darkgraylib.command_line
-from darkgraylib.command_line import add_parser_argument
 from graylint import help as hlp
 from graylint.version import __version__
 
@@ -25,9 +23,5 @@ def make_argument_parser(require_src: bool) -> ArgumentParser:
         __version__
     )
 
-    def add_arg(help_text: Optional[str], *name_or_flags: str, **kwargs: Any) -> None:
-        kwargs["help"] = help_text
-        parser.add_argument(*name_or_flags, **kwargs)
-
-    add_arg(hlp.LINT, "-L", "--lint", action="append", metavar="CMD", default=[])
+    parser.add_argument("-L", "--lint", action="append", metavar="CMD", default=[])
     return parser

--- a/src/graylint/config.py
+++ b/src/graylint/config.py
@@ -1,10 +1,12 @@
 """Load and save configuration in TOML format"""
 
-from typing import List
+from __future__ import annotations
+
 from darkgraylib.config import BaseConfig
 
 
 class GraylintConfig(BaseConfig):
     """Dictionary representing ``[tool.graylint]`` from ``pyproject.toml``"""
 
-    lint: List[str]
+    lint: list[str]
+    output_format: dict[str, str]

--- a/src/graylint/help.py
+++ b/src/graylint/help.py
@@ -12,3 +12,10 @@ LINT = (
     " output is syntax highlighted when the `pygments` package is available if run on"
     " a terminal and or enabled by explicitly (see `--color`)."
 )
+
+FORMAT_TEMPLATE = (
+    "Specify output format and destination. Format can be one of:"
+    " {output_format_names}. Optional destination path can be specified after colon,"
+    " e.g. 'gnu:-' for stdout or 'gnu:annotations.txt' for file output. Multiple "
+    " formats can be specified with comma separation or by repeating the option."
+)

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -26,12 +26,20 @@ import os
 import re
 import shlex
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from tempfile import TemporaryDirectory
-from typing import IO, Callable, Collection, Generator, Iterable
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Callable,
+    Collection,
+    Generator,
+    Iterable,
+    Sequence,
+)
 
 from darkgraylib.diff import map_unmodified_lines
 from darkgraylib.git import (
@@ -43,8 +51,11 @@ from darkgraylib.git import (
     git_get_root,
     git_rev_parse,
 )
-from darkgraylib.highlighting import colorize
 from darkgraylib.utils import WINDOWS
+from graylint.output import create_output_plugin
+
+if TYPE_CHECKING:
+    from graylint.command_line import OutputSpec
 
 logger = logging.getLogger(__name__)
 
@@ -372,7 +383,7 @@ def run_linters(
     root: Path,
     paths: set[Path],
     revrange: RevisionRange,
-    use_color: bool,
+    output_spec: Sequence[OutputSpec],
 ) -> int:
     """Run the given linters on a set of files in the repository, filter messages
 
@@ -389,7 +400,7 @@ def run_linters(
     :param root: The root of the relative paths
     :param paths: The files and directories to check, relative to ``root``
     :param revrange: The Git revisions to compare
-    :param use_color: ``True`` to use syntax highlighting for linter output
+    :param output_spec: The output formats and destinations for linter messages
     :raises NotImplementedError: if ``--stdin-filename`` is used
     :return: Total number of linting errors found on modified lines
 
@@ -414,7 +425,7 @@ def run_linters(
             baseline={},
             new_messages=messages,
             diff_line_mapping=DiffLineMapping(),
-            use_color=use_color,
+            output_spec=output_spec,
         )
     git_paths = {(root / path).relative_to(git_root) for path in paths}
     # 10. first do a temporary checkout at `rev1` and run linter subprocesses once for
@@ -438,7 +449,9 @@ def run_linters(
     diff_line_mapping = _create_line_mapping(git_root, files_with_messages, revrange)
     # 12. hide linter messages which appear in the current versions and identically on
     #     corresponding lines in ``rev1``, and show all other linter messages
-    return _print_new_linter_messages(baseline, messages, diff_line_mapping, use_color)
+    return _print_new_linter_messages(
+        baseline, messages, diff_line_mapping, output_spec
+    )
 
 
 def _identity_line_processor(message: LinterMessage) -> LinterMessage:
@@ -502,14 +515,14 @@ def _print_new_linter_messages(
     baseline: dict[MessageLocation, list[LinterMessage]],
     new_messages: dict[MessageLocation, list[LinterMessage]],
     diff_line_mapping: DiffLineMapping,
-    use_color: bool,
+    output_spec: Sequence[OutputSpec],
 ) -> int:
     """Print all linter messages except those same as before on unmodified lines
 
     :param baseline: Linter messages and their locations for a previous version
     :param new_messages: New linter messages in a new version of the source file
     :param diff_line_mapping: Mapping between unmodified lines in old and new versions
-    :param use_color: ``True`` to highlight linter messages in the output
+    :param output_spec: The output formats and destinations for linter messages
     :return: The number of linter errors displayed
 
     """
@@ -517,26 +530,33 @@ def _print_new_linter_messages(
         _log_messages(baseline, new_messages)
     error_count = 0
     prev_location = NO_MESSAGE_LOCATION
-    for message_location, messages in sorted(new_messages.items()):
-        old_location = diff_line_mapping.get(message_location)
-        is_modified_line = old_location == NO_MESSAGE_LOCATION
-        old_messages: list[LinterMessage] = baseline.get(old_location, [])
-        for message in messages:
-            if not is_modified_line and normalize_whitespace(message) in old_messages:
-                # Only hide messages when
-                # - they occurred previously on the corresponding line
-                # - the line hasn't been modified
-                continue
-            if (
-                message_location.path != prev_location.path
-                or message_location.line > prev_location.line + 1
-            ):
-                print()
-            prev_location = message_location
-            print(colorize(f"{message_location}:", "lint_location", use_color), end=" ")
-            print(colorize(message.description, "lint_description", use_color), end=" ")
-            print(f"[{message.linter}]")
-            error_count += 1
+    with ExitStack() as stack:
+        outputs = [
+            stack.enter_context(create_output_plugin(output)) for output in output_spec
+        ]
+        for message_location, messages in sorted(new_messages.items()):
+            old_location = diff_line_mapping.get(message_location)
+            is_modified_line = old_location == NO_MESSAGE_LOCATION
+            old_messages: list[LinterMessage] = baseline.get(old_location, [])
+            for message in messages:
+                if (
+                    not is_modified_line
+                    and normalize_whitespace(message) in old_messages
+                ):
+                    # Only hide messages when
+                    # - they occurred previously on the corresponding line
+                    # - the line hasn't been modified
+                    continue
+                group_boundary = (
+                    message_location.path != prev_location.path
+                    or message_location.line > prev_location.line + 1
+                )
+                prev_location = message_location
+                for output in outputs:
+                    if group_boundary:
+                        output.group_delimiter()
+                    output.output(message_location, message)
+                error_count += 1
     return error_count
 
 

--- a/src/graylint/output/__init__.py
+++ b/src/graylint/output/__init__.py
@@ -1,0 +1,3 @@
+"""Built-in output format plugins."""
+
+OUTPUT_FORMAT_GROUP = "graylint.output_format"

--- a/src/graylint/output/__init__.py
+++ b/src/graylint/output/__init__.py
@@ -1,3 +1,24 @@
 """Built-in output format plugins."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from darkgraylib.plugins import create_plugin
+
+if TYPE_CHECKING:
+    from graylint.command_line import OutputSpec
+    from graylint.output.base import OutputPlugin
+
+
 OUTPUT_FORMAT_GROUP = "graylint.output_format"
+
+
+def create_output_plugin(spec: OutputSpec) -> OutputPlugin:
+    """Create an output plugin based on the specification."""
+    from graylint.output.base import OutputPlugin
+
+    plugin = create_plugin(
+        OUTPUT_FORMAT_GROUP, spec.format, spec.path, use_color=spec.use_color
+    )
+    return cast(OutputPlugin, plugin)

--- a/src/graylint/output/base.py
+++ b/src/graylint/output/base.py
@@ -1,0 +1,37 @@
+"""Base class for output plugins."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Self
+
+if TYPE_CHECKING:
+    from graylint.linting import LinterMessage, MessageLocation
+    from graylint.output.destination import OutputDestination
+
+
+class OutputPlugin:
+    """Base class for output plugins."""
+
+    def __init__(self, destination: OutputDestination, *, use_color: bool) -> None:
+        """Initialize the output plugin."""
+        self._destination = destination
+        self._use_color = use_color
+
+    def __enter__(self) -> Self:
+        """Open the output stream to enter the context manager."""
+        self._stream = self._destination.open()
+        return self
+
+    def __exit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> Literal[False]:
+        """Close the output stream to exit the context manager."""
+        self._destination.close()
+        return False
+
+    def output(self, location: MessageLocation, message: LinterMessage) -> None:
+        """Output a message in the desired format."""
+        raise NotImplementedError
+
+    def group_delimiter(self) -> None:
+        """Output a delimiter between groups of messages."""

--- a/src/graylint/output/destination.py
+++ b/src/graylint/output/destination.py
@@ -1,0 +1,64 @@
+"""Encapsulate path/device/stdout handling in a class."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import TextIO
+
+
+class OutputDestination:
+    """Encapsulate path/device/stdout handling in a class."""
+
+    def __init__(self, path_or_dash: Path | str) -> None:
+        """Initialize the output destination class."""
+        if isinstance(path_or_dash, str) and path_or_dash == "-":
+            self._path: Path | None = None
+            self._file = sys.stdout
+        else:
+            self._path = path_or_dash
+            self._file = None
+
+    def open(self) -> TextIO:
+        """Open the output destination for writing.
+
+        :raises TypeError: If the output destination object is invalid.
+
+        """
+        if self._file == sys.stdout and self._path is None:
+            return sys.stdout
+        if isinstance(self._path, Path) and self._file is None:
+            self._file = self._path.open("w")
+            return self._file
+        message = f"Invalid OutputDestination object {self!r}"
+        raise TypeError(message)
+
+    def close(self) -> None:
+        """Close the output destination."""
+        if self._file != sys.stdout:
+            self._file.close()
+
+    @property
+    def path(self) -> Path:
+        """The path to the output destination."""
+        if self._file == sys.stdout and self._path is None:
+            message = "stdout has no path"
+            raise ValueError(message)
+        if isinstance(self._path, Path):
+            return self._path
+        message = f"Invalid OutputDestination object {self!r}"
+        raise TypeError(message)
+
+    def __repr__(self) -> str:
+        """Return a string representation of the path or device."""
+        path = "-" if self._file == sys.stdout else self._path
+        return f"{self.__class__.__name__}({path!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Compare two output destinations."""
+        if not isinstance(other, OutputDestination):
+            return False
+        return self._path == other._path

--- a/src/graylint/output/github.py
+++ b/src/graylint/output/github.py
@@ -1,0 +1,17 @@
+"""GitHub output plugin for Graylint."""
+
+from graylint.linting import LinterMessage, MessageLocation
+from graylint.output.base import OutputPlugin
+
+
+class GitHubOutputPlugin(OutputPlugin):
+    """Output plugin for GitHub message annotations."""
+
+    def output(self, location: MessageLocation, message: LinterMessage) -> None:
+        """Output a message in the GitHub message annotation format."""
+        print("::error", end=" ", file=self._stream)
+        print(f"file={location.path}", end=",", file=self._stream)
+        print(f"line={location.line}", end=",", file=self._stream)
+        if location.column:
+            print(f"col={location.column}", end=",", file=self._stream)
+        print(f"title={message.linter}::{message.description}", file=self._stream)

--- a/src/graylint/output/gnu.py
+++ b/src/graylint/output/gnu.py
@@ -1,0 +1,30 @@
+"""Output plugin for GNU error format."""
+
+from darkgraylib.highlighting import colorize
+from graylint.linting import LinterMessage, MessageLocation
+from graylint.output.base import OutputPlugin
+
+
+class GnuErrorFormatOutputPlugin(OutputPlugin):
+    """Output plugin for GNU error format."""
+
+    def output(self, location: MessageLocation, message: LinterMessage) -> None:
+        """Output a message in the GNU error format."""
+        loc = (
+            f"{location.path}:{location.line}:{location.column}:"
+            if location.column
+            else f"{location.path}:{location.line}:"
+        )
+        print(
+            colorize(loc, "lint_location", self._use_color), end=" ", file=self._stream
+        )
+        print(
+            colorize(message.description, "lint_description", self._use_color),
+            end=" ",
+            file=self._stream,
+        )
+        print(f"[{message.linter}]", file=self._stream)
+
+    def group_delimiter(self) -> None:
+        """Output a delimiter between groups of messages."""
+        print(file=self._stream)

--- a/src/graylint/tests/test_command_line.py
+++ b/src/graylint/tests/test_command_line.py
@@ -10,8 +10,9 @@ import pytest
 
 from darkgraylib.command_line import parse_command_line
 from darkgraylib.testtools.helpers import raises_if_exception
-from graylint.command_line import make_argument_parser
+from graylint.command_line import OutputSpec, make_argument_parser
 from graylint.config import GraylintConfig
+from graylint.output.destination import OutputDestination
 
 
 @pytest.mark.kwparametrize(
@@ -47,6 +48,12 @@ def test_make_argument_parser(require_src, expect):
         expect_config=("lint", ["flake8", "mypy"]),
         expect_modified=("lint", ["flake8", "mypy"]),
     ),
+    dict(
+        argv=["-o", "gnu", "."],
+        expect_value=("output_format", [OutputSpec("gnu", OutputDestination("-"))]),
+        expect_config=("output_format", [OutputSpec("gnu", OutputDestination("-"))]),
+        expect_modified=("output_format", ...),
+    ),
 )
 def test_parse_command_line(
     tmp_path,
@@ -65,7 +72,6 @@ def test_parse_command_line(
     with patch.dict(os.environ, {}, clear=True), raises_if_exception(
         expect_value,
     ) as expect_exception:
-
         args, effective_cfg, modified_cfg = parse_command_line(
             make_argument_parser,
             argv,

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -1,6 +1,6 @@
-# pylint: disable=protected-access,too-many-arguments,use-dict-literal
+"""Unit tests for `graylint.linting`."""
 
-"""Unit tests for `graylint.linting`"""
+# pylint: disable=protected-access,too-many-arguments,use-dict-literal
 
 import os
 from pathlib import Path
@@ -15,6 +15,7 @@ from darkgraylib.git import WORKTREE, RevisionRange
 from darkgraylib.testtools.helpers import raises_if_exception
 from darkgraylib.utils import WINDOWS
 from graylint import linting
+from graylint.command_line import OutputSpec
 from graylint.linting import (
     DiffLineMapping,
     LinterMessage,
@@ -355,7 +356,7 @@ def test_run_linters(
     revrange = RevisionRange("HEAD", ":WORKTREE:")
 
     linting.run_linters(
-        cmdlines, git_repo.root, {Path("dummy path")}, revrange, use_color=False
+        cmdlines, git_repo.root, {Path("dummy path")}, revrange, [OutputSpec("gnu")]
     )
 
     # We can now verify that the linter received the correct paths on its command line
@@ -382,7 +383,7 @@ def test_run_linters_non_worktree():
             RevisionRange.parse_with_common_ancestor(
                 "..HEAD", Path("dummy cwd"), stdin_mode=False
             ),
-            use_color=False,
+            [OutputSpec("gnu")],
         )
 
 
@@ -405,7 +406,7 @@ def test_run_linters_return_value(git_repo, message, expect):
         git_repo.root,
         {Path("test.py")},
         RevisionRange("HEAD", ":WORKTREE:"),
-        use_color=False,
+        [OutputSpec("gnu")],
     )
 
     assert result == expect
@@ -426,7 +427,7 @@ def test_run_linters_on_new_file(git_repo, capsys):
         Path(git_repo.root),
         {Path("file2.py")},
         RevisionRange("initial", ":WORKTREE:"),
-        use_color=False,
+        [OutputSpec("gnu")],
     )
 
     output = capsys.readouterr().out.splitlines()
@@ -458,7 +459,7 @@ def test_run_linters_line_separation(git_repo, capsys):
         git_repo.root,
         {Path(p) for p in paths},
         RevisionRange("HEAD", ":WORKTREE:"),
-        use_color=False,
+        [OutputSpec("gnu")],
     )
 
     result = capsys.readouterr().out
@@ -487,7 +488,7 @@ def test_run_linters_stdin():
             Path("/dummy-dir"),
             {Path("dummy.py")},
             RevisionRange("HEAD", ":STDIN:"),
-            use_color=False,
+            [OutputSpec("gnu")],
         )
 
 
@@ -541,7 +542,7 @@ def test_print_new_linter_messages(capsys):
         )
 
     linting._print_new_linter_messages(
-        baseline, new_messages, diff_line_mapping, use_color=False
+        baseline, new_messages, diff_line_mapping, [OutputSpec("gnu")]
     )
 
     result = capsys.readouterr().out.splitlines()

--- a/src/graylint/tests/test_output_destination.py
+++ b/src/graylint/tests/test_output_destination.py
@@ -1,0 +1,51 @@
+"""Tests for `graylint.output.destination.OutputDestination`."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from darkgraylib.testtools.helpers import raises_if_exception
+from graylint.output.destination import OutputDestination
+
+
+@pytest.mark.kwparametrize(
+    dict(path_or_dash="-", expect_name=sys.stdout.name, expect_mode=sys.stdout.mode),
+    dict(path_or_dash=Path("test.txt"), expect_name="test.txt", expect_mode="w"),
+    dict(path_or_dash="invalid", expect_name=TypeError, expect_mode=TypeError),
+)
+def test_open(tmp_path, monkeypatch, path_or_dash, expect_name, expect_mode):
+    """OutputDestination.open() returns a file object for writing."""
+    monkeypatch.chdir(tmp_path)
+    destination = OutputDestination(path_or_dash)
+
+    with raises_if_exception(expect_name):
+        result = destination.open()
+
+        expect_attrs = (expect_name, False, expect_mode)
+        assert (result.name, result.closed, result.mode) == expect_attrs
+
+
+@pytest.mark.kwparametrize(
+    dict(path_or_dash="-", expect=False),
+    dict(path_or_dash=Path("test.txt"), expect=True),
+)
+def test_close(tmp_path, monkeypatch, path_or_dash, expect):
+    """OutputDestination.open() returns a file object for writing."""
+    monkeypatch.chdir(tmp_path)
+    destination = OutputDestination(path_or_dash)
+    stream = destination.open()
+
+    with raises_if_exception(expect):
+        destination.close()
+
+    assert stream.closed == expect
+
+
+@pytest.mark.kwparametrize(
+    dict(left=OutputDestination("-"), right=OutputDestination("-"), expect=True)
+)
+def test_equality(left, right, expect):
+    """OutputDestination instances are equal if their destinations are equal."""
+    equality = left == right
+    assert equality == expect


### PR DESCRIPTION
Output plugins allow changing the output format. This PR includes the following built-in ouput plugins:
- [GNU error format] (used by most linters by default)
- [GitHub annotations] (to annotate changed files in the GitHub Pull Request web interface)

[GNU error format]: https://www.gnu.org/prep/standards/standards.html#Errors
[GitHub annotations]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message