### PR TITLE
Linter parser plugin system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "darkgraylib>=2.4.0,<3.0.dev0",
+    "darkgraylib>=2.4.1,<3.0.dev0",
 ]
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync
 #       with the minimum required Python version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "darkgraylib>=2.4.1,<3.0.dev0",
+    "typing-extensions>=3.6.2 ; python_version < '3.12'",
 ]
 # NOTE: remember to keep `.github/workflows/python-package.yml` in sync
 #       with the minimum required Python version
@@ -60,13 +61,22 @@ News = "https://github.com/akaihola/graylint/discussions/categories/announcement
 [project.scripts]
 graylint = "graylint.__main__:main_with_error_handling"
 
-# plugin entry points:
+# output plugin entry points:
 [project.entry-points."graylint.output_format"]
 gnu = "graylint.output.gnu:GnuErrorFormatOutputPlugin"
 github = "graylint.output.github:GitHubOutputPlugin"
 
+# linter error parsing plugin entry points:
+[project.entry-points."graylint.linter_parser"]
+gnu = "graylint.linter_parser.gnu:GnuErrorFormatParserPlugin"
+
 [tool.setuptools]
-packages = ["graylint", "graylint.output", "graylint.tests"]
+packages = [
+    "graylint",
+    "graylint.linter_parser",
+    "graylint.output",
+    "graylint.tests",
+]
 package-dir = {"" = "src"}
 py-modules = []
 license-files = ["LICENSE.rst"]
@@ -125,9 +135,10 @@ ignore = [
     "ANN201",  # Missing return type annotation for public function
     "ANN204",  # Missing return type annotation for special method `__init__`
     "INP001",  # File is part of an implicit namespace package
-    "C408",  # Unnecessary `dict` call (rewrite as a literal)
-    "PLR0913",  # Too many arguments in function definition
-    "S101",  # Use of `assert` detected
+    "C408",    # Unnecessary `dict` call (rewrite as a literal)
+    "D103",    # Missing docstring in public function
+    "PLR0913", # Too many arguments in function definition
+    "S101",    # Use of `assert` detected
     "SLF001",  # Private member accessed
 ]
 "action/tests/*.py" = [

--- a/src/graylint/linter_parser/__init__.py
+++ b/src/graylint/linter_parser/__init__.py
@@ -1,0 +1,1 @@
+"""Plugins for parsing linter output."""

--- a/src/graylint/linter_parser/base.py
+++ b/src/graylint/linter_parser/base.py
@@ -1,0 +1,28 @@
+"""Base class for linter parsers."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from graylint.linter_parser.message import LinterMessage, MessageLocation
+
+
+class LinterParser(ABC):  # pylint: disable=too-few-public-methods
+    """Base class for linter parsers."""
+
+    name = "base-linter-parser"
+
+    @abstractmethod
+    def parse(
+        self, linter: str, linter_output: str, cwd: Path
+    ) -> dict[MessageLocation, list[LinterMessage]]:
+        """Parse the output of a linter.
+
+        :param linter_output: The complete output of the linter
+        :return: A mapping of linter message locations to linter messages
+
+        """
+        raise NotImplementedError
+
+
+class ParserError(Exception):
+    """Exception raised when a linter parser fails to parse a linter output."""

--- a/src/graylint/linter_parser/gnu.py
+++ b/src/graylint/linter_parser/gnu.py
@@ -1,0 +1,133 @@
+"""Parser plugin for GNU error format."""
+
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+from graylint.linter_parser.base import LinterParser
+from graylint.linter_parser.message import INVALID_LINE, LinterMessage, MessageLocation
+
+logger = logging.getLogger(__name__)
+
+
+def _strict_nonneg_int(text: str) -> int:
+    """Strict parsing of strings to non-negative integers.
+
+    Allow no leading or trailing whitespace, nor plus or minus signs.
+
+    :param text: The string to convert
+    :raises ValueError: Raises if the string has any non-numeric characters
+    :return: The parsed non-negative integer value
+
+    """
+    if text.strip("+-\t ") != text:
+        msg = f"invalid literal for int() with base 10: {text}"
+        raise ValueError(msg)
+    return int(text)
+
+
+class GnuErrorFormatParserPlugin(LinterParser):
+    """GNU error format parser plugin."""
+
+    name = "gnu"
+
+    def parse(
+        self, linter: str, linter_output: str, cwd: Path  # noqa: ARG002
+    ) -> dict[MessageLocation, list[LinterMessage]]:
+        """Parse the output of a linter which uses GNU error format.
+
+        :param linter_output: The complete output of the linter
+        :return: A mapping of linter message locations to linter messages
+
+        """
+        messages: dict[MessageLocation, list[LinterMessage]] = defaultdict(list)
+        for line in linter_output.splitlines(keepends=True):
+            location, message = self.parse_gnu_error_line(linter, line)
+            if location != INVALID_LINE:
+                messages[location].append(message)
+        return messages
+
+    def parse_gnu_error_line(
+        self, linter: str, line: str
+    ) -> tuple[MessageLocation, LinterMessage]:
+        """Parse one line of linter output.
+
+        Only parses lines with
+        - a relative or absolute file path (without leading-trailing whitespace),
+        - a non-negative line number (without leading/trailing whitespace),
+        - optionally a column number (without leading/trailing whitespace), and
+        - a description.
+
+        Examples of successfully parsed lines::
+
+            path/to/file.py:42: Description
+            /absolute/path/to/file.py:42:5: Description
+
+        These would be parsed into::
+
+            (
+                MessageLocation(Path("path/to/file.py"), 42, 0),
+                LinterMessage("linter", "Description"),
+            )
+            (
+                MessageLocation(Path("/absolute/path/to/file.py"), 42, 5),
+                LinterMessage("linter", "Description"),
+            )
+
+        For all other lines, an ``INVALID_LINE`` dummy entry is returned:
+        an empty path, zero as the line number, -2 as the column,
+        and an empty description.
+
+        Such lines should be simply ignored, since many linters display supplementary
+        information insterspersed with the actual linting notifications.
+
+        Linter-specific plugins should enhance the parsing logic to return a
+        ``DISCARDED_LINE`` dummy entry for any additional valid recognized output.
+        Those entries will be counted towards the score of the plugin, and the highest
+        scoring plugin will be used as the actual parser.
+
+        :param linter: The name of the linter
+        :param line: The linter output line to parse. May have a trailing newline.
+        :return: A 2-tuple of objects with
+                 - the file path, line and column numbers of the linter message, and
+                 - the linter name and message description.
+
+        """
+
+        def _check_filename_whitespace(path_str: str) -> None:
+            if path_str.strip() != path_str:
+                msg = f"Filename {path_str!r} has leading/trailing whitespace"
+                raise ValueError(msg)
+
+        def _check_token_count(location: str, rest: list[str]) -> None:
+            if len(rest) > 1:
+                msg = f"Too many colon-separated tokens in {location!r}"
+                raise ValueError(msg)
+
+        try:
+            location, description = line.rstrip().split(": ", 1)
+            if location[1:3] == ":\\":
+                # Absolute Windows paths need special handling. Separate out the ``C:``
+                # (or similar), then split by colons, and finally re-insert the ``C:``.
+                path_in_drive, linenum_str, *rest = location[2:].split(":")
+                path_str = f"{location[:2]}{path_in_drive}"
+            else:
+                path_str, linenum_str, *rest = location.split(":")
+            _check_filename_whitespace(path_str)
+            linenum = _strict_nonneg_int(linenum_str)
+            _check_token_count(location, rest)
+            # Make sure the column looks like an int in "<path>:<linenum>:<column>":
+            column = _strict_nonneg_int(rest[0]) if len(rest) == 1 else 0
+        except ValueError as exc:
+            # Encountered a non-parsable line which doesn't express a linting error.
+            # For example, on Mypy:
+            #   >Found XX errors in YY files (checked ZZ source files)
+            #   >Success: no issues found in 1 source file
+            logger.debug("Unparsable linter output: %s", line[:-1])
+            logger.debug("Reason: %s", exc)
+            return (INVALID_LINE, LinterMessage(linter, ""))
+        path = Path(path_str)
+        return (
+            MessageLocation(path, linenum, column),
+            LinterMessage(linter, description),
+        )

--- a/src/graylint/linter_parser/message.py
+++ b/src/graylint/linter_parser/message.py
@@ -1,0 +1,47 @@
+"""Data types for linter error messages and their locations in a file."""
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+
+@dataclass(eq=True, frozen=True, order=True)
+class MessageLocation:
+    """A file path, line number and column number for a linter message.
+
+    Line and column numbers a 0-based, and zero is used for an unspecified column, and
+    for the non-specified location.
+
+    """
+
+    path: Path
+    line: int
+    column: int = 0
+
+    @override
+    def __str__(self) -> str:
+        """Convert file path, line and column into a linter line prefix string.
+
+        :return: Either ``"path:line:column"`` or ``"path:line"`` (if column is zero)
+
+        """
+        if self.column:
+            return f"{self.path}:{self.line}:{self.column}"
+        return f"{self.path}:{self.line}"
+
+
+DISCARDED_LINE = MessageLocation(Path(), 0, -1)
+INVALID_LINE = MessageLocation(Path(), 0, -2)
+
+
+@dataclass
+class LinterMessage:
+    """Information about a linter message."""
+
+    linter: str
+    description: str

--- a/src/graylint/linter_parser/plugin_helpers.py
+++ b/src/graylint/linter_parser/plugin_helpers.py
@@ -1,0 +1,38 @@
+"""Helpers for using linter parser plugins."""
+
+from __future__ import annotations
+
+import sys
+from importlib.metadata import EntryPoint, entry_points
+from typing import TYPE_CHECKING, cast
+
+from darkgraylib.plugins import (
+    create_plugin,
+    get_entry_point_names,
+)
+
+if TYPE_CHECKING:
+    from graylint.linter_parser.base import LinterParser
+
+ENTRY_POINT_GROUP = "graylint.linter_parser"
+
+
+def get_linter_parser_entry_points() -> tuple[EntryPoint, ...]:
+    """Get the entry points of all built-in linter parser plugins."""
+    if sys.version_info < (3, 10):
+        return tuple(entry_points()[ENTRY_POINT_GROUP])
+    result = entry_points(group=ENTRY_POINT_GROUP)
+    return cast("tuple[EntryPoint, ...]", result)
+
+
+def create_linter_parser_plugins() -> list[LinterParser]:
+    """Create and manage multiple linter parser plugins as context managers.
+
+    :output_spec: List of linter parser names to create plugins for
+    :return: List of initialized linter parser objects
+
+    """
+    return [
+        cast("LinterParser", create_plugin(ENTRY_POINT_GROUP, name))
+        for name in get_entry_point_names(ENTRY_POINT_GROUP)
+    ]

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -52,7 +52,12 @@ from darkgraylib.git import (
 )
 from darkgraylib.utils import WINDOWS
 from graylint.linter_parser.base import LinterParser, ParserError
-from graylint.linter_parser.message import INVALID_LINE, LinterMessage, MessageLocation
+from graylint.linter_parser.message import (
+    DISCARDED_LINE,
+    INVALID_LINE,
+    LinterMessage,
+    MessageLocation,
+)
 from graylint.linter_parser.plugin_helpers import create_linter_parser_plugins
 from graylint.output.plugin_helpers import create_output_plugins
 
@@ -228,7 +233,11 @@ def drop_messages_for_missing_files(
     result: dict[MessageLocation, list[LinterMessage]] = defaultdict(list)
     flattened = ((loc, msg) for loc, msgs in messages.items() for msg in msgs)
     for location, message in flattened:
-        if location is INVALID_LINE or location.path in missing_files:
+        if (
+            location is INVALID_LINE
+            or location is DISCARDED_LINE
+            or location.path in missing_files
+        ):
             continue
         if location.path.is_absolute():
             try:

--- a/src/graylint/linting.py
+++ b/src/graylint/linting.py
@@ -27,7 +27,6 @@ import re
 import shlex
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from tempfile import TemporaryDirectory
@@ -52,6 +51,9 @@ from darkgraylib.git import (
     git_rev_parse,
 )
 from darkgraylib.utils import WINDOWS
+from graylint.linter_parser.base import LinterParser, ParserError
+from graylint.linter_parser.message import INVALID_LINE, LinterMessage, MessageLocation
+from graylint.linter_parser.plugin_helpers import create_linter_parser_plugins
 from graylint.output.plugin_helpers import create_output_plugins
 
 if TYPE_CHECKING:
@@ -59,41 +61,6 @@ if TYPE_CHECKING:
     from graylint.copy_settings import CopySettingsStorage
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(eq=True, frozen=True, order=True)
-class MessageLocation:
-    """A file path, line number and column number for a linter message
-
-    Line and column numbers a 0-based, and zero is used for an unspecified column, and
-    for the non-specified location.
-
-    """
-
-    path: Path
-    line: int
-    column: int = 0
-
-    def __str__(self) -> str:
-        """Convert file path, line and column into a linter line prefix string
-
-        :return: Either ``"path:line:column"`` or ``"path:line"`` (if column is zero)
-
-        """
-        if self.column:
-            return f"{self.path}:{self.line}:{self.column}"
-        return f"{self.path}:{self.line}"
-
-
-NO_MESSAGE_LOCATION = MessageLocation(Path(""), 0, 0)
-
-
-@dataclass
-class LinterMessage:
-    """Information about a linter message"""
-
-    linter: str
-    description: str
 
 
 class DiffLineMapping:
@@ -133,7 +100,7 @@ class DiffLineMapping:
         if key in self._mapping:
             (old_path, old_line) = self._mapping[key]
             return MessageLocation(old_path, old_line, new_location.column)
-        return NO_MESSAGE_LOCATION
+        return INVALID_LINE
 
 
 def normalize_whitespace(message: LinterMessage) -> LinterMessage:
@@ -172,96 +139,6 @@ def make_linter_env(root: Path, revision: str) -> dict[str, str]:
         "GRAYLINT_ORIG_REPO": str(root),
         "GRAYLINT_REV_COMMIT": ("WORKTREE" if revision == "WORKTREE" else revision[:7]),
     }
-
-
-def _strict_nonneg_int(text: str) -> int:
-    """Strict parsing of strings to non-negative integers
-
-    Allow no leading or trailing whitespace, nor plus or minus signs.
-
-    :param text: The string to convert
-    :raises ValueError: Raises if the string has any non-numeric characters
-    :return: [description]
-    :rtype: [type]
-    """
-    if text.strip("+-\t ") != text:
-        raise ValueError(r"invalid literal for int() with base 10: {text}")
-    return int(text)
-
-
-def _parse_linter_line(
-    linter: str, line: str, cwd: Path
-) -> tuple[MessageLocation, LinterMessage]:
-    """Parse one line of linter output
-
-    Only parses lines with
-    - a relative or absolute file path (without leading-trailing whitespace),
-    - a non-negative line number (without leading/trailing whitespace),
-    - optionally a column number (without leading/trailing whitespace), and
-    - a description.
-
-    Examples of successfully parsed lines::
-
-        path/to/file.py:42: Description
-        /absolute/path/to/file.py:42:5: Description
-
-    Given ``cwd=Path("/absolute")``, these would be parsed into::
-
-        (Path("path/to/file.py"), 42, "path/to/file.py:42:", "Description")
-        (Path("path/to/file.py"), 42, "path/to/file.py:42:5:", "Description")
-
-    For all other lines, a dummy entry is returned: an empty path, zero as the line
-    number, an empty location string and an empty description. Such lines should be
-    simply ignored, since many linters display supplementary information insterspersed
-    with the actual linting notifications.
-
-    :param linter: The name of the linter
-    :param line: The linter output line to parse. May have a trailing newline.
-    :param cwd: The directory in which the linter was run, and relative to which paths
-                are returned
-    :return: A 2-tuple of
-             - the file path, line and column numbers of the linter message, and
-             - the linter name and message description.
-
-    """
-    try:
-        location, description = line.rstrip().split(": ", 1)
-        if location[1:3] == ":\\":
-            # Absolute Windows paths need special handling. Separate out the ``C:`` (or
-            # similar), then split by colons, and finally re-insert the ``C:``.
-            path_in_drive, linenum_str, *rest = location[2:].split(":")
-            path_str = f"{location[:2]}{path_in_drive}"
-        else:
-            path_str, linenum_str, *rest = location.split(":")
-        if path_str.strip() != path_str:
-            raise ValueError(r"Filename {path_str!r} has leading/trailing whitespace")
-        linenum = _strict_nonneg_int(linenum_str)
-        if len(rest) > 1:
-            raise ValueError("Too many colon-separated tokens in {location!r}")
-        if len(rest) == 1:
-            # Make sure the column looks like an int in "<path>:<linenum>:<column>"
-            column = _strict_nonneg_int(rest[0])  # noqa: F841
-        else:
-            column = 0
-    except ValueError:
-        # Encountered a non-parsable line which doesn't express a linting error.
-        # For example, on Mypy:
-        # "Found XX errors in YY files (checked ZZ source files)"
-        # "Success: no issues found in 1 source file"
-        logger.debug("Unparsable linter output: %s", line[:-1])
-        return (NO_MESSAGE_LOCATION, LinterMessage(linter, ""))
-    path = Path(path_str)
-    if path.is_absolute():
-        try:
-            path = path.relative_to(cwd)
-        except ValueError:
-            logger.warning(
-                "Linter message for a file %s outside root directory %s",
-                path_str,
-                cwd,
-            )
-            return (NO_MESSAGE_LOCATION, LinterMessage(linter, ""))
-    return (MessageLocation(path, linenum, column), LinterMessage(linter, description))
 
 
 def _require_rev2_worktree(rev2: str) -> None:
@@ -334,12 +211,58 @@ def _transform_linter_command(cmdline: list[str]) -> list[str]:
     return transformed_cmdline
 
 
+def drop_messages_for_missing_files(
+    linter: str,
+    messages: dict[MessageLocation, list[LinterMessage]],
+    root: Path,
+    missing_files: set[Path],
+) -> dict[MessageLocation, list[LinterMessage]]:
+    """Drop messages for files which are not in the given set of paths.
+
+    :param messages: The linter messages to filter
+    :param root: The common root of all files to lint
+    :param missing_files: A set to which paths of missing files are added
+    :return: The filtered linter messages
+
+    """
+    result: dict[MessageLocation, list[LinterMessage]] = defaultdict(list)
+    flattened = ((loc, msg) for loc, msgs in messages.items() for msg in msgs)
+    for location, message in flattened:
+        if location is INVALID_LINE or location.path in missing_files:
+            continue
+        if location.path.is_absolute():
+            try:
+                path = location.path.relative_to(root)
+            except ValueError:
+                logger.warning(
+                    "Linter message for a file %s outside root directory %s",
+                    location.path,
+                    root,
+                )
+                continue
+        else:
+            path = location.path
+        if location.path.suffix != ".py":
+            logger.warning(
+                "Linter message for a non-Python file: %s: %s",
+                location,
+                message.description,
+            )
+            continue
+        if not location.path.is_file() and not location.path.is_symlink():
+            logger.warning("Missing file %s from %s messages", path, linter)
+            missing_files.add(location.path)
+            continue
+        result[location].append(message)
+    return result
+
+
 def run_linter(  # pylint: disable=too-many-locals
     cmdline: list[str],
     root: Path,
     paths: Collection[Path],
     env: dict[str, str],
-) -> dict[MessageLocation, LinterMessage]:
+) -> tuple[dict[MessageLocation, list[LinterMessage]], LinterParser]:
     """Run the given linter and return linting errors falling on changed lines
 
     :param cmdline: The command line for running the linter
@@ -349,32 +272,39 @@ def run_linter(  # pylint: disable=too-many-locals
     :return: The number of modified lines with linting errors from this linter
 
     """
-    missing_files = set()
-    result = {}
+    missing_files: set[Path] = set()
     transformed_cmdline = _transform_linter_command(cmdline)
-    linter = transformed_cmdline[0]
-    cmdline_str = shlex.join(transformed_cmdline)
     # 10. run a linter subprocess for files mentioned on the command line which may be
     #     modified or unmodified, to get current linting status in the working tree
     #     (steps 10.-12. are optional)
     with _check_linter_output(transformed_cmdline, root, paths, env) as linter_stdout:
-        for line in linter_stdout:
-            (location, message) = _parse_linter_line(linter, line, root)
-            if location is NO_MESSAGE_LOCATION or location.path in missing_files:
-                continue
-            if location.path.suffix != ".py":
-                logger.warning(
-                    "Linter message for a non-Python file: %s: %s",
-                    location,
-                    message.description,
-                )
-                continue
-            if not location.path.is_file() and not location.path.is_symlink():
-                logger.warning("Missing file %s from %s", location.path, cmdline_str)
-                missing_files.add(location.path)
-                continue
-            result[location] = message
-    return result
+        output = linter_stdout.read()
+        return parse_linter_output(transformed_cmdline, output, root, missing_files)
+
+
+def parse_linter_output(
+    cmdline: list[str], output: str, root: Path, missing_files: set[Path]
+) -> tuple[dict[MessageLocation, list[LinterMessage]], LinterParser]:
+    """Parse linter output and return a dictionary of messages and their locations."""
+    linter = cmdline[0]
+    messages: dict[MessageLocation, list[LinterMessage]] | None = None
+    chosen_parser: LinterParser | None = None
+    linter_plugins = create_linter_parser_plugins()
+    for parser_plugin in linter_plugins:
+        try:
+            messages_from_this_linter = parser_plugin.parse(linter, output, root)
+        except ParserError:
+            continue
+        if messages is None or len(messages_from_this_linter) > len(messages.keys()):
+            messages = messages_from_this_linter
+            chosen_parser = parser_plugin
+    if messages is None or chosen_parser is None:
+        msg = f"No linter parser could parse the output of {shlex.join(cmdline)}"
+        raise ValueError(msg)
+    messages_for_existing_files = drop_messages_for_missing_files(
+        linter, messages, root, missing_files
+    )
+    return (messages_for_existing_files, chosen_parser)
 
 
 # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -487,8 +417,10 @@ def _get_messages_from_linters(
     """
     result = defaultdict(list)
     for cmdline in linter_cmdlines:
-        for message_location, message in run_linter(cmdline, root, paths, env).items():
-            result[message_location].append(line_processor(message))
+        (messages, _) = run_linter(cmdline, root, paths, env)
+        for message_location, msgs in messages.items():
+            for message in msgs:
+                result[message_location].append(line_processor(message))
     return result
 
 
@@ -533,11 +465,11 @@ def _print_new_linter_messages(
     if logger.getEffectiveLevel() <= logging.DEBUG:
         _log_messages(baseline, new_messages)
     error_count = 0
-    prev_location = NO_MESSAGE_LOCATION
+    prev_location = INVALID_LINE
     with create_output_plugins(output_spec) as outputs:
         for message_location, messages in sorted(new_messages.items()):
             old_location = diff_line_mapping.get(message_location)
-            is_modified_line = old_location == NO_MESSAGE_LOCATION
+            is_modified_line = old_location == INVALID_LINE
             old_messages: list[LinterMessage] = baseline.get(old_location, [])
             for message in messages:
                 if (

--- a/src/graylint/output/base.py
+++ b/src/graylint/output/base.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
-    from graylint.linting import LinterMessage, MessageLocation
+    from graylint.linter_parser.message import LinterMessage, MessageLocation
     from graylint.output.destination import OutputDestination
 
 
@@ -28,9 +28,9 @@ class OutputPlugin:
 
     def __init__(self, destination: OutputDestination, *, use_color: bool) -> None:
         """Initialize the output plugin."""
-        self._destination = destination
-        self._use_color = use_color
-        self._stream = NULL_STREAM
+        self._destination: OutputDestination = destination
+        self._use_color: bool = use_color
+        self._stream: TextIO = NULL_STREAM
 
     def __enter__(self) -> Self:
         """Open the output stream to enter the context manager."""

--- a/src/graylint/output/github.py
+++ b/src/graylint/output/github.py
@@ -1,6 +1,6 @@
 """GitHub output plugin for Graylint."""
 
-from graylint.linting import LinterMessage, MessageLocation
+from graylint.linter_parser.message import LinterMessage, MessageLocation
 from graylint.output.base import OutputPlugin
 
 

--- a/src/graylint/output/gnu.py
+++ b/src/graylint/output/gnu.py
@@ -1,8 +1,12 @@
 """Output plugin for GNU error format."""
 
+import re
+
 from darkgraylib.highlighting import colorize
 from graylint.linting import LinterMessage, MessageLocation
 from graylint.output.base import OutputPlugin
+
+JOIN_LINES_RE = re.compile(r"\s*\n+\s*")
 
 
 class GnuErrorFormatOutputPlugin(OutputPlugin):
@@ -19,7 +23,11 @@ class GnuErrorFormatOutputPlugin(OutputPlugin):
             colorize(loc, "lint_location", self._use_color), end=" ", file=self._stream
         )
         print(
-            colorize(message.description, "lint_description", self._use_color),
+            colorize(
+                JOIN_LINES_RE.sub(" / ", message.description),
+                "lint_description",
+                self._use_color,
+            ),
             end=" ",
             file=self._stream,
         )

--- a/src/graylint/output/gnu.py
+++ b/src/graylint/output/gnu.py
@@ -3,7 +3,7 @@
 import re
 
 from darkgraylib.highlighting import colorize
-from graylint.linting import LinterMessage, MessageLocation
+from graylint.linter_parser.message import LinterMessage, MessageLocation
 from graylint.output.base import OutputPlugin
 
 JOIN_LINES_RE = re.compile(r"\s*\n+\s*")

--- a/src/graylint/tests/test_github.py
+++ b/src/graylint/tests/test_github.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from graylint.linting import LinterMessage, MessageLocation
+from graylint.linter_parser.message import LinterMessage, MessageLocation
 from graylint.output.destination import OutputDestination
 from graylint.output.github import GitHubOutputPlugin
 

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from subprocess import PIPE, Popen  # nosec
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 from unittest.mock import patch
 
 import pytest
@@ -22,18 +22,15 @@ from darkgraylib.utils import WINDOWS
 from graylint import linting
 from graylint.command_line import OutputSpec, shlex_split
 from graylint.copy_settings import CopySettingsStorage
-from graylint.linting import (
-    DiffLineMapping,
-    LinterMessage,
-    MessageLocation,
-    make_linter_env,
-)
+from graylint.linter_parser.message import INVALID_LINE, LinterMessage, MessageLocation
+from graylint.linting import DiffLineMapping, make_linter_env
+from graylint.tests.testhelpers import SKIP_ON_UNIX, SKIP_ON_WINDOWS
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
+    from contextlib import AbstractContextManager
 
-SKIP_ON_WINDOWS = [pytest.mark.skip] if WINDOWS else []
-SKIP_ON_UNIX = [] if WINDOWS else [pytest.mark.skip]
+    from _pytest.fixtures import SubRequest
 
 
 @pytest.mark.kwparametrize(
@@ -54,19 +51,19 @@ def test_message_location_str(column, expect):
         new_location=("/path/to/new_file.py", 43, 8),
         old_location=("/path/to/old_file.py", 42, 13),
         get_location=("/path/to/new_file.py", 43, 21),
-        expect_location=("/path/to/old_file.py", 42, 21),
+        expect_location=MessageLocation(Path("/path/to/old_file.py"), 42, 21),
     ),
     dict(
         new_location=("/path/to/new_file.py", 43, 8),
         old_location=("/path/to/old_file.py", 42, 13),
         get_location=("/path/to/a_different_file.py", 43, 21),
-        expect_location=("", 0, 0),
+        expect_location=INVALID_LINE,
     ),
     dict(
         new_location=("/path/to/file.py", 43, 8),
         old_location=("/path/to/file.py", 42, 13),
         get_location=("/path/to/file.py", 42, 21),
-        expect_location=("", 0, 0),
+        expect_location=INVALID_LINE,
     ),
 )
 def test_diff_line_mapping_ignores_column(
@@ -77,12 +74,11 @@ def test_diff_line_mapping_ignores_column(
     new_location_ = MessageLocation(Path(new_location[0]), *new_location[1:])
     old_location = MessageLocation(Path(old_location[0]), *old_location[1:])
     get_location = MessageLocation(Path(get_location[0]), *get_location[1:])
-    expect = MessageLocation(Path(expect_location[0]), *expect_location[1:])
 
     mapping[new_location_] = old_location
     result = mapping.get(get_location)
 
-    assert result == expect
+    assert result == expect_location
 
 
 def test_normalize_whitespace():
@@ -95,82 +91,6 @@ def test_normalize_whitespace():
     assert result == LinterMessage(
         "mylinter", "module.py:42: indented message, trailing spaces and tabs"
     )
-
-
-@pytest.fixture(scope="module")
-def parse_linter_line_repo(request, tmp_path_factory):
-    """Git repository fixture for `test_parse_linter_line`."""
-    with GitRepoFixture.context(request, tmp_path_factory) as repo:
-        yield repo
-
-
-@pytest.mark.kwparametrize(
-    dict(
-        line="module.py:42: Just a line number\n",
-        expect=(Path("module.py"), 42, 0, "Just a line number"),
-    ),
-    dict(
-        line="module.py:42:5: With column  \n",
-        expect=(Path("module.py"), 42, 5, "With column"),
-    ),
-    dict(
-        line="{git_root_absolute}{sep}mod.py:42: Full path\n",
-        expect=(Path("mod.py"), 42, 0, "Full path"),
-    ),
-    dict(
-        line="{git_root_absolute}{sep}mod.py:42:5: Full path with column\n",
-        expect=(Path("mod.py"), 42, 5, "Full path with column"),
-    ),
-    dict(
-        line="mod.py:42: 123 digits start the description\n",
-        expect=(Path("mod.py"), 42, 0, "123 digits start the description"),
-    ),
-    dict(
-        line="mod.py:42:    indented description\n",
-        expect=(Path("mod.py"), 42, 0, "   indented description"),
-    ),
-    dict(
-        line="mod.py:42:5:    indented description\n",
-        expect=(Path("mod.py"), 42, 5, "   indented description"),
-    ),
-    dict(
-        line="nonpython.txt:5: Non-Python file\n",
-        expect=(Path("nonpython.txt"), 5, 0, "Non-Python file"),
-    ),
-    dict(line="mod.py: No line number\n", expect=(Path(), 0, 0, "")),
-    dict(line="mod.py:foo:5: Invalid line number\n", expect=(Path(), 0, 0, "")),
-    dict(line="mod.py:42:bar: Invalid column\n", expect=(Path(), 0, 0, "")),
-    dict(
-        line="/outside/mod.py:5: Outside the repo\n",
-        expect=(Path(), 0, 0, ""),
-        marks=SKIP_ON_WINDOWS,
-    ),
-    dict(
-        line="C:\\outside\\mod.py:5: Outside the repo\n",
-        expect=(Path(), 0, 0, ""),
-        marks=SKIP_ON_UNIX,
-    ),
-    dict(line="invalid linter output\n", expect=(Path(), 0, 0, "")),
-    dict(line=" leading:42: whitespace\n", expect=(Path(), 0, 0, "")),
-    dict(line=" leading:42:5 whitespace and column\n", expect=(Path(), 0, 0, "")),
-    dict(line="trailing :42: filepath whitespace\n", expect=(Path(), 0, 0, "")),
-    dict(line="leading: 42: linenum whitespace\n", expect=(Path(), 0, 0, "")),
-    dict(line="trailing:42 : linenum whitespace\n", expect=(Path(), 0, 0, "")),
-    dict(line="plus:+42: before linenum\n", expect=(Path(), 0, 0, "")),
-    dict(line="minus:-42: before linenum\n", expect=(Path(), 0, 0, "")),
-    dict(line="plus:42:+5 before column\n", expect=(Path(), 0, 0, "")),
-    dict(line="minus:42:-5 before column\n", expect=(Path(), 0, 0, "")),
-)
-def test_parse_linter_line(parse_linter_line_repo, monkeypatch, line, expect):
-    """Linter output is parsed correctly"""
-    root = parse_linter_line_repo.root
-    monkeypatch.chdir(root)
-    root_abs = root.absolute()
-    line_expanded = line.format(git_root_absolute=root_abs, sep=os.sep)
-
-    result = linting._parse_linter_line("linter", line_expanded, root)
-
-    assert result == (MessageLocation(*expect[:3]), LinterMessage("linter", expect[3]))
 
 
 @pytest.mark.kwparametrize(
@@ -205,7 +125,9 @@ def test_check_linter_output(tmp_path, cmdline, expect):
 
 
 @pytest.fixture(scope="module")
-def run_linters_repo(request, tmp_path_factory):
+def run_linters_repo(
+    request: SubRequest, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[GitRepoFixture]:
     """Git repository fixture for `test_run_linters`."""
     # pylint: disable=no-member  # pylint bug?
     with GitRepoFixture.context(request, tmp_path_factory) as repo:
@@ -310,7 +232,7 @@ def test_run_linters(
     messages_after: list[str],
     expect_output: list[str],
     expect_log: list[str],
-):
+) -> None:
     """Linter gets correct paths on command line and outputs just changed lines
 
     We use ``cat`` as our "linter". It just gets the content of the given file.
@@ -412,7 +334,12 @@ def test_run_linters_return_value(simple_test_repo, message, expect):
     assert result == expect
 
 
-def test_run_linters_on_new_file(simple_test_repo, make_temp_copy, monkeypatch, capsys):
+def test_run_linters_on_new_file(
+    simple_test_repo: SimpleNamespace,
+    make_temp_copy: Callable[[Path], AbstractContextManager[Path]],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """``run_linters()`` considers file missing from history as empty
 
     Passes through all linter errors as if the original file was empty.
@@ -438,7 +365,11 @@ def test_run_linters_on_new_file(simple_test_repo, make_temp_copy, monkeypatch, 
     ]
 
 
-def test_run_linters_line_separation(simple_test_repo, make_temp_copy, capsys):
+def test_run_linters_line_separation(
+    simple_test_repo: SimpleNamespace,
+    make_temp_copy: Callable[[Path], AbstractContextManager[Path]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """``run_linters`` separates contiguous blocks of linter output with empty lines"""
     with make_temp_copy(simple_test_repo.root) as root:
         linter_output = root / "dummy-linter-output.txt"
@@ -689,3 +620,44 @@ def test_transform_linter_command(cmdline, expect):
     else:
         result = linting._transform_linter_command(cmdline)
         assert result == expect
+
+
+@pytest.mark.kwparametrize(
+    dict(
+        output=dedent(
+            """
+            ************* Module src.graylint.linter_parser.gnu
+            subdir/first.py:30:0: C0301: Line too long (104/100) (line-too-long)
+
+            ------------------------------------------------------------------
+            Your code has been rated at 4.67/10 (previous run: 4.67/10, +0.00)
+
+            """
+        ),
+        expect_parser="gnu",
+        expect_messages={
+            MessageLocation(Path("subdir/first.py"), 30, 0): [
+                LinterMessage(
+                    linter="pylint",
+                    description="C0301: Line too long (104/100) (line-too-long)",
+                )
+            ],
+        },
+    ),
+)
+def test_parse_linter_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    output: str,
+    expect_parser: str,
+    expect_messages: dict[MessageLocation, list[LinterMessage]],
+) -> None:
+    """Test that the correct plugin is used and parses messages correctly."""
+    monkeypatch.chdir(tmp_path)
+    Path("subdir").mkdir()
+    Path("subdir/first.py").touch()
+    Path("subdir/second.py").touch()
+    (result, parser) = linting.parse_linter_output(["pylint"], output, Path(), set())
+
+    assert parser.name == expect_parser
+    assert result == expect_messages

--- a/src/graylint/tests/test_linting.py
+++ b/src/graylint/tests/test_linting.py
@@ -224,27 +224,27 @@ def run_linters_repo(request, tmp_path_factory):
 
 @pytest.mark.kwparametrize(
     dict(
-        _descr="New message for test.py",
+        # New message for test.py
         messages_after=["test.py:1: new message"],
         expect_output=["", "test.py:1: new message [cat]"],
     ),
     dict(
-        _descr="New message for test.py, including column number",
+        # New message for test.py, including column number
         messages_after=["test.py:1:42: new message with column number"],
         expect_output=["", "test.py:1:42: new message with column number [cat]"],
     ),
     dict(
-        _descr="Identical message on an unmodified unmoved line in test.py",
+        # Identical message on an unmodified unmoved line in test.py
         messages_before=["test.py:1:42: same message on same line"],
         messages_after=["test.py:1:42: same message on same line"],
     ),
     dict(
-        _descr="Identical message on an unmodified moved line in test.py",
+        # Identical message on an unmodified moved line in test.py
         messages_before=["test.py:3:42: same message on a moved line"],
         messages_after=["test.py:4:42: same message on a moved line"],
     ),
     dict(
-        _descr="Additional message on an unmodified moved line in test.py",
+        # Additional message on an unmodified moved line in test.py
         messages_before=["test.py:3:42: same message"],
         messages_after=[
             "test.py:4:42: same message",
@@ -253,13 +253,13 @@ def run_linters_repo(request, tmp_path_factory):
         expect_output=["", "test.py:4:42: additional message [cat]"],
     ),
     dict(
-        _descr="Changed message on an unmodified moved line in test.py",
+        # Changed message on an unmodified moved line in test.py
         messages_before=["test.py:4:42: old message"],
         messages_after=["test.py:4:42: new message"],
         expect_output=["", "test.py:4:42: new message [cat]"],
     ),
     dict(
-        _descr="Identical message but on an inserted line in test.py",
+        # Identical message but on an inserted line in test.py
         messages_before=["test.py:1:42: same message also on an inserted line"],
         messages_after=[
             "test.py:1:42: same message also on an inserted line",
@@ -268,19 +268,19 @@ def run_linters_repo(request, tmp_path_factory):
         expect_output=["", "test.py:2:42: same message also on an inserted line [cat]"],
     ),
     dict(
-        _descr="Warning for a file missing from the working tree",
+        # Warning for a file missing from the working tree
         messages_after=["missing.py:1: a missing Python file"],
         expect_log=["WARNING Missing file missing.py from cat messages"],
     ),
     dict(
-        _descr="Linter message for a non-Python file is ignored with a warning",
+        # Linter message for a non-Python file is ignored with a warning
         messages_after=["nonpython.txt:1: non-py"],
         expect_log=[
             "WARNING Linter message for a non-Python file: nonpython.txt:1: non-py"
         ],
     ),
     dict(
-        _descr="Message for file outside common root is ignored with a warning (Unix)",
+        # Message for file outside common root is ignored with a warning (Unix)
         messages_after=["/elsewhere/mod.py:1: elsewhere"],
         expect_log=[
             "WARNING Linter message for a file /elsewhere/mod.py outside root"
@@ -289,7 +289,7 @@ def run_linters_repo(request, tmp_path_factory):
         marks=SKIP_ON_WINDOWS,
     ),
     dict(
-        _descr="Message for file outside common root is ignored with a warning (Win)",
+        # Message for file outside common root is ignored with a warning (Win)
         messages_after=["C:\\elsewhere\\mod.py:1: elsewhere"],
         expect_log=[
             "WARNING Linter message for a file C:\\elsewhere\\mod.py outside root"
@@ -302,15 +302,14 @@ def run_linters_repo(request, tmp_path_factory):
     expect_log=[],
 )
 def test_run_linters(
-    run_linters_repo,
-    make_temp_copy,
-    capsys,
-    caplog,
-    _descr,
-    messages_before,
-    messages_after,
-    expect_output,
-    expect_log,
+    run_linters_repo: GitRepoFixture,
+    make_temp_copy: Callable[[Path], AbstractContextManager[Path]],
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+    messages_before: list[str],
+    messages_after: list[str],
+    expect_output: list[str],
+    expect_log: list[str],
 ):
     """Linter gets correct paths on command line and outputs just changed lines
 

--- a/src/graylint/tests/test_parser_gnu.py
+++ b/src/graylint/tests/test_parser_gnu.py
@@ -1,0 +1,109 @@
+"""Test the GNU error format parser plugin."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from darkgraylib.testtools.git_repo_plugin import GitRepoFixture
+from graylint.linter_parser.gnu import GnuErrorFormatParserPlugin
+from graylint.linter_parser.message import INVALID_LINE, LinterMessage, MessageLocation
+from graylint.tests.testhelpers import SKIP_ON_UNIX, SKIP_ON_WINDOWS
+
+
+@pytest.fixture
+def gnu_parser() -> GnuErrorFormatParserPlugin:
+    """Fixture for the GNU error format parser plugin."""
+    return GnuErrorFormatParserPlugin()
+
+
+@pytest.fixture(scope="module")
+def parse_linter_line_repo(request, tmp_path_factory):
+    """Git repository fixture for `test_parse_linter_line`."""
+    with GitRepoFixture.context(request, tmp_path_factory) as repo:
+        yield repo
+
+
+def test_empty(gnu_parser: GnuErrorFormatParserPlugin) -> None:
+    """Test parsing an empty string."""
+    messages = gnu_parser.parse("linter", "", Path("/cwd"))
+    assert messages == {}
+
+
+@pytest.mark.kwparametrize(
+    dict(
+        line="module.py:42: Just a line number\n",
+        expect=("module.py", 42, 0, "Just a line number"),
+    ),
+    dict(
+        line="module.py:42:5: With column  \n",
+        expect=("module.py", 42, 5, "With column"),
+    ),
+    dict(
+        line="{git_root_absolute}{sep}mod.py:42: Full path\n",
+        expect=("{git_root_absolute}{sep}mod.py", 42, 0, "Full path"),
+    ),
+    dict(
+        line="{git_root_absolute}{sep}mod.py:42:5: Full path with column\n",
+        expect=("{git_root_absolute}{sep}mod.py", 42, 5, "Full path with column"),
+    ),
+    dict(
+        line="mod.py:42: 123 digits start the description\n",
+        expect=("mod.py", 42, 0, "123 digits start the description"),
+    ),
+    dict(
+        line="mod.py:42:    indented description\n",
+        expect=("mod.py", 42, 0, "   indented description"),
+    ),
+    dict(
+        line="mod.py:42:5:    indented description\n",
+        expect=("mod.py", 42, 5, "   indented description"),
+    ),
+    dict(
+        line="nonpython.txt:5: Non-Python file\n",
+        expect=("nonpython.txt", 5, 0, "Non-Python file"),
+    ),
+    dict(line="mod.py: No line number\n", expect=INVALID_LINE),
+    dict(line="mod.py:foo:5: Invalid line number\n", expect=INVALID_LINE),
+    dict(line="mod.py:42:bar: Invalid column\n", expect=INVALID_LINE),
+    dict(
+        line="/outside/mod.py:5: Outside the repo\n",
+        expect=("/outside/mod.py", 5, 0, "Outside the repo"),
+        marks=SKIP_ON_WINDOWS,
+    ),
+    dict(
+        line="C:\\outside\\mod.py:5: Outside the repo\n",
+        expect=("C:\\outside\\mod.py", 5, 0, "Outside the repo"),
+        marks=SKIP_ON_UNIX,
+    ),
+    dict(line="invalid linter output\n", expect=INVALID_LINE),
+    dict(line=" leading:42: whitespace\n", expect=INVALID_LINE),
+    dict(line=" leading:42:5 whitespace and column\n", expect=INVALID_LINE),
+    dict(line="trailing :42: filepath whitespace\n", expect=INVALID_LINE),
+    dict(line="leading: 42: linenum whitespace\n", expect=INVALID_LINE),
+    dict(line="trailing:42 : linenum whitespace\n", expect=INVALID_LINE),
+    dict(line="plus:+42: before linenum\n", expect=INVALID_LINE),
+    dict(line="minus:-42: before linenum\n", expect=INVALID_LINE),
+    dict(line="plus:42:+5 before column\n", expect=INVALID_LINE),
+    dict(line="minus:42:-5 before column\n", expect=INVALID_LINE),
+)
+def test_parse_linter_line(
+    parse_linter_line_repo, gnu_parser, monkeypatch, line, expect
+):
+    """Linter output is parsed correctly."""
+    root = parse_linter_line_repo.root
+    monkeypatch.chdir(root)
+    root_abs = root.absolute()
+    line_expanded = line.format(git_root_absolute=root_abs, sep=os.sep)
+
+    result = gnu_parser.parse_gnu_error_line("linter", line_expanded)
+
+    if expect is INVALID_LINE:
+        expect_location = INVALID_LINE
+        expect_message = LinterMessage("linter", "")
+    else:
+        expect_location = MessageLocation(
+            Path(expect[0].format(git_root_absolute=root_abs, sep=os.sep)), *expect[1:3]
+        )
+        expect_message = LinterMessage("linter", expect[3])
+    assert result == (expect_location, expect_message)

--- a/src/graylint/tests/testhelpers.py
+++ b/src/graylint/tests/testhelpers.py
@@ -1,0 +1,8 @@
+"""Platform-specific test skipping."""
+
+import pytest
+
+from darkgraylib.utils import WINDOWS
+
+SKIP_ON_WINDOWS = [pytest.mark.skip] if WINDOWS else []
+SKIP_ON_UNIX = [] if WINDOWS else [pytest.mark.skip]


### PR DESCRIPTION
The plugin system will allow for parsing for other linter error message output formats than the GNU error format, and also some linter-specific variants of the GNU error format.

Specifically, this will enable precise parsing of output from
- [The Ruff Linter]
- [Pyrefly]
- [ty]
- [basedpyright] and [pyright] (both human-readable and `--outputjson` output)

[The Ruff Linter]: https://docs.astral.sh/ruff/linter/
[Pyrefly]: https://pyrefly.org/
[ty]: https://docs.astral.sh/ty/
[basedpyright]: https://docs.basedpyright.com/latest/
[pyright]: https://microsoft.github.io/pyright/